### PR TITLE
Encode Cython as a setup-time dependency of vowpal porpoise

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,11 @@
 import setuptools
 import setuptools.extension
+
+setuptools.dist.Distribution(dict(setup_requires='Cython'))
+# `setup_requires` is parsed and acted upon immediately; from here on out
+# the yoursharedsetuppackage is installed and importable.
+# Thanks to Martijn Pieters http://stackoverflow.com/a/12061891/351084
+
 from Cython.Distutils import build_ext
 
 setuptools.setup(name='vowpal_porpoise',


### PR DESCRIPTION
Encoding Cython as a setup-time dependency makes it much easer to use vowpal porpoise in nicely packaged distributions.

Without Cython as a setup-time dependency, you might have a requirements.txt with these lines:
  Cython
  git+http://github.com/josephreisinger/vowpal_porpoise.git#egg=vowpal_porpoise
and try to execute "pip install -r requirements.txt" (or, for instance, push to Heroku and expect it to do so).

Unfortunately the installation process for Cython will not be completed before vowpal porpoise needs it.  By specifying Cython as a setup-time dependency in the vowpal porpoise setup.py, Cython will be downloaded and available _before_ it is needed, and you don't have to specify it as a dependency elsewhere.  Using my modified setup.py, I can now run "pip install git+http://github.com/josephreisinger/vowpal_porpoise.git#egg=vowpal_porpoise" without any mention of Cython.
