### PR TITLE
Added support for nn (single layer) in sklearn interface

### DIFF
--- a/vowpal_porpoise/sklearn.py
+++ b/vowpal_porpoise/sklearn.py
@@ -43,7 +43,8 @@ class _VW(sklearn.base.BaseEstimator):
                  oaa=None,
                  old_model=None,
                  incremental=False,
-                 mem=None
+                 mem=None,
+                 nn=None,
                  ):
         self.logger = logger
         self.vw = vw
@@ -74,6 +75,7 @@ class _VW(sklearn.base.BaseEstimator):
         self.old_model = old_model
         self.incremental = incremental
         self.mem = mem
+        self.nn = nn
 
     def fit(self, X, y):
         """Fit Vowpal Wabbit
@@ -118,6 +120,7 @@ class _VW(sklearn.base.BaseEstimator):
             old_model=self.old_model,
             incremental=self.incremental,
             mem=self.mem,
+            nn=self.nn
         )
 
         # add examples to model
@@ -157,7 +160,6 @@ class VW_Classifier(sklearn.base.ClassifierMixin, _VW):
 
     def predict(self, X):
         result = super(VW_Classifier, self).predict(X)
-        result = 2 * (result >= 0) - 1
         return result
 
 

--- a/vowpal_porpoise/vw.py
+++ b/vowpal_porpoise/vw.py
@@ -41,6 +41,7 @@ class VW:
                  old_model=None,
                  incremental=False,
                  mem=None,
+                 nn=None,
                  **kwargs):
         assert moniker and passes
 
@@ -100,6 +101,7 @@ class VW:
         self.oaa = oaa
         self.bfgs = bfgs
         self.mem = mem
+        self.nn = nn
 
         # Do some sanity checking for compatability between models
         if self.lda:
@@ -143,6 +145,7 @@ class VW:
         if self.audit:                           l.append('--audit')
         if self.bfgs:                            l.append('--bfgs')
         if self.adaptive:                        l.append('--adaptive')
+        if self.nn                  is not None: l.append('--nn=%d' % self.nn)
         return ' '.join(l)
 
     def vw_train_command(self, cache_file, model_file):


### PR DESCRIPTION
Adding support for nn to be called from the wrapper.

[DEBUG] Running command: "vw --learning_rate=5.000000 --l2=0.000010 --oaa=10 --nn=4 --passes 10 --cache_file /home/vvkulkarni/vowpal_porpoise/examples/example_sklearn.cache -f /home/vvkulkarni/vowpal_porpoise/examples/example_sklearn.model"
[DEBUG] Running command: "vw --learning_rate=5.000000 --l2=0.000010 --oaa=10 --nn=4 -t -i /home/vvkulkarni/vowpal_porpoise/examples/example_sklearn.model -p /home/vvkulkarni/vowpal_porpoise/examples/example_sklearn.predictionecqcFA"
Confusion Matrix:
[[34  0  0  0  1  0  0  0  0  0]
 [ 0 29  0  0  0  0  0  0  0  7]
 [ 0  0 35  0  0  0  0  0  0  0]
 [ 0  0  0 24  0  4  0  3  6  0]
 [ 0  0  0  0 34  0  0  0  3  0]
 [ 0  0  0  0  0 37  0  0  0  0]
 [ 0  0  0  0  0  0 37  0  0  0]
 [ 0  0  0  1  0  0  0 32  2  1]
 [ 0  1  0  0  0  1  0  1 30  0]
 [ 0  0  0  0  0  2  0  1  3 31]]
0.89717036724
Adding @aboSamoor (as he is interested in this CL too)
