### PR TITLE
Make tagged VW data work

### DIFF
--- a/vowpal_porpoise/vw.py
+++ b/vowpal_porpoise/vw.py
@@ -233,7 +233,7 @@ class VW:
         if self.lda:
             return map(float, p.split())
         else:
-            return float(p)
+            return float(p.split()[0])
 
     def read_predictions_(self):
         for x in open(self.prediction_file):


### PR DESCRIPTION
For whatever reason, when the VW data is tagged, the parser barfs on reading the prediction file because it gets the prediction value and the tag back. This fixes it for me.
